### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
       fail-fast: false
       matrix:
         BACKEND: [memory, cassandra, scylladb, hbase, rocksdb]
-        java-version: ['8', '8.0.192']
+        JAVA_VERSION: ['8']
     steps:
-      - name: Install JDK ${{ matrix.java-version }}
+      - name: Install JDK ${{ matrix.JAVA_VERSION }}
         uses: actions/setup-java@v2
         with:
-          java-version: ${{ matrix.java-version }}
+          java-version: ${{ matrix.JAVA_VERSION }}
           distribution: 'zulu'
 
       - name: Cache Maven packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,13 @@ jobs:
       fail-fast: false
       matrix:
         BACKEND: [memory, cassandra, scylladb, hbase, rocksdb]
+        java-version: ['8', '8.0.192']
     steps:
-      - name: Install JDK 8
+      - name: Install JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '8'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'zulu'
 
       - name: Cache Maven packages
         uses: actions/cache@v2


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK. Also, added a fixed (major) version. It's good practice to use a fix version for an LTS release of OpenJDK. Sometimes getting the latest builds can break when customers or vendors have fixed(major) jdk releases in production. If the latest build is red (failed) and the fixed version is green (passed) then you know right away it was not your code that broke it. 

Temurin, is the successor of (AdoptOpenJDK/Adoptium -> Eclipse Foundation), however some major fixed version releases are not supported (prior to July 2021) and many non-LTS versions, if you decide to test drive new features in the JDK. 

Switching to Zulu is nice because it supports every version released of the OpenJDK including non-LTS fixed versions and early access releases. It's also TCK tested and AdoptOpenJDK builds are not.